### PR TITLE
Add exported clause database snapshots

### DIFF
--- a/prolog.rkt
+++ b/prolog.rkt
@@ -7,7 +7,9 @@
     extend-bindings substitute-bindings variables-in
     replace-anonymous-variables unify object->string
     remove-clauses-with-arity!
-    current-clause-database add-clause! get-clauses <- <-- define-predicate
+    current-clause-database primitive-clause-database
+    standard-clause-database
+    add-clause! get-clauses <- <-- define-predicate
     prove-all ?- current-lisp-environment
     success-bindings success-continuation solve-first solve-all)
 

--- a/prolog.scm
+++ b/prolog.scm
@@ -119,6 +119,8 @@
 
 (define current-clause-database (make-parameter '()))
 
+(define primitive-clause-database (make-parameter '()))
+(define standard-clause-database (make-parameter '()))
 (define (get-clauses predicate-symbol)
   (let ((entry (assoc predicate-symbol (current-clause-database))))
     (if entry (cdr entry) '())))
@@ -426,10 +428,6 @@
          (new-bindings (unify prolog-variable (parameter) (current-bindings))))
     (prove-all (current-remaining-goals) new-bindings)))
 
-(<-- (lisp ?result ?expression) (lisp-eval-internal ?result ?expression))
-(<-- (is ?result ?expression) (lisp-eval-internal ?result ?expression))
-(<-- (lisp ?expression) (lisp-eval-internal ? ?expression))
-
 
 (define-predicate (add-solution-and-fail template)
   (let* ((substituted-template (substitute-bindings (current-bindings) template))
@@ -460,6 +458,10 @@
            (new-bindings (unify result-set sorted-solutions (current-bindings)))
            (goals (current-remaining-goals)))
       (prove-all goals new-bindings))))
+(primitive-clause-database (current-clause-database))
+(<-- (lisp ?result ?expression) (lisp-eval-internal ?result ?expression))
+(<-- (is ?result ?expression) (lisp-eval-internal ?result ?expression))
+(<-- (lisp ?expression) (lisp-eval-internal ? ?expression))
 
 (<-- (or ?goal-a ?goal-b) (call ?goal-a))
 (<- (or ?goal-a ?goal-b) (call ?goal-b))
@@ -483,3 +485,4 @@
 
 (<-- (not ?goal) (call ?goal) (cut) (fail))
 (<- (not ?goal))
+(standard-clause-database (current-clause-database))

--- a/prolog.sld
+++ b/prolog.sld
@@ -3,7 +3,9 @@
   (export
     variable? named-variable? atom? failure? success?
     extend-bindings substitute-bindings variables-in replace-anonymous-variables
-    unify object->string remove-clauses-with-arity! current-clause-database
+    unify object->string remove-clauses-with-arity!
+    current-clause-database primitive-clause-database
+    standard-clause-database
     add-clause! get-clauses <- <-- define-predicate prove-all ?-
     current-lisp-environment
     success-bindings success-continuation solve-first solve-all)

--- a/prolog.sls
+++ b/prolog.sls
@@ -6,7 +6,9 @@
     extend-bindings substitute-bindings variables-in
     replace-anonymous-variables unify object->string
     remove-clauses-with-arity!
-    current-clause-database add-clause! get-clauses <- <-- define-predicate
+    current-clause-database primitive-clause-database
+    standard-clause-database
+    add-clause! get-clauses <- <-- define-predicate
     prove-all ?- current-lisp-environment
     success-bindings success-continuation solve-first solve-all)
 


### PR DESCRIPTION
## Summary
- add primitive-clause-database and standard-clause-database parameters
- capture primitive and standard clause database states in `prolog.scm`
- export these databases from all Scheme library variants

## Testing
- `make IMPLS=racket`

------
https://chatgpt.com/codex/tasks/task_b_68521f438f648322b879be2472d81373