### PR TITLE
Add zero-arity and/or tests

### DIFF
--- a/test.scm
+++ b/test.scm
@@ -230,6 +230,10 @@
                      (and (solve-first '((repeat)) 'dummy)
                           (loop (+ n 1))))))
   (test-assert "true/0 always succeeds" (not (null? (solve-all '((true)) 'dummy))))
+  (test-assert "and/0 behaves as true"
+               (not (null? (solve-all '((and)) 'dummy))))
+  (test-assert "or/0 behaves as fail"
+               (null? (solve-all '((or)) 'dummy)))
   )
 
 ;; -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- add regression tests verifying `and` with no arguments succeeds
- add regression tests verifying `or` with no arguments fails

## Testing
- `nix develop -c make IMPLS=gauche`

------
https://chatgpt.com/codex/tasks/task_b_68528eca57608322a51a9754682a1882