### PR TITLE
Implement findall predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Athena Reasoner is a lightweight Prolog-inspired logic programming engine implem
 
 - Unification with optional occurs check and backtracking
 - Anonymous variable renaming to avoid clashes
-- Built-in predicates such as `=`, `==`, `not`, `if`, `bagof`, `setof`, `cut` and more
+- Built-in predicates such as `=`, `==`, `not`, `if`, `bagof`, `findall`, `setof`, `cut` and more
 - Interactive query syntax with the `?-` macro
 
 ## Requirements
@@ -114,7 +114,7 @@ The library provides a number of predicates implemented in Scheme:
 - `lisp` / `is` – evaluate Scheme expressions
 - `repeat` – backtracking loop
 - `member`, `append` – common list utilities
-- `bagof`, `setof` – collect solutions
+- `bagof`, `findall`, `setof` – collect solutions
 - `fail` – force failure
 - `dynamic-put`, `dynamic-get` – store and retrieve dynamic variables
 

--- a/prolog.scm
+++ b/prolog.scm
@@ -437,6 +437,15 @@
            (goals (current-remaining-goals)))
       (prove-all goals new-bindings))))
 
+(define-predicate (findall template goal result-list)
+  (parameterize ((current-solution-accumulator '()))
+    (let ((new-goals (list goal (list '--add-solution-and-fail template) 'fail)))
+      (prove-all new-goals (current-bindings)))
+    (let* ((reversed-solutions (reverse (current-solution-accumulator)))
+           (new-bindings (unify result-list reversed-solutions (current-bindings)))
+           (goals (current-remaining-goals)))
+      (prove-all goals new-bindings))))
+
 (define-predicate (setof template goal result-set)
   (define (sort-predicate a b)
     (let ((string-a (object->string a))

--- a/test.scm
+++ b/test.scm
@@ -155,8 +155,10 @@
 
   (<- (item a)) (<- (item b)) (<- (item a))
   (test-equal "bagof gets all solutions" '(mary michael) (solve-first '((bagof ?c (parent john ?c) ?l)) '?l))
+  (test-equal "findall gets all solutions" '(mary michael) (solve-first '((findall ?c (parent john ?c) ?l)) '?l))
   (test-equal "setof gets unique sorted" '(david mary michael susan) (solve-first '((setof ?x (ancestor john ?x) ?o)) '?o))
   (test-equal "bagof vs setof" '((a b a) (a b)) (solve-first '((bagof ?x (item ?x) ?bag) (setof ?x (item ?x) ?set)) '(?bag ?set)))
+  (test-equal "findall with no solutions" '() (solve-first '((findall ?x (parent susan ?x) ?l)) '?l))
 
   (test-equal "cut prunes choices" '(1) (solve-all '((bar ?v)) '?v))
   (test-equal "no cut finds all" '(1 2 3) (solve-all '((foo ?x) (= ?x ?x)) '?x)))


### PR DESCRIPTION
## Summary
- add `findall` as a built‑in predicate
- document `findall` in README
- add tests for `findall`

## Testing
- `nix develop -c make all`

------
https://chatgpt.com/codex/tasks/task_b_6854b1687e688322b4dd55f156c53836