### PR TITLE
Add README instructions for spy and tweak prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ The library provides a number of predicates implemented in Scheme:
 - `fail` – force failure
 - `dynamic-put`, `dynamic-get` – store and retrieve dynamic variables
 
+## Debugging with Spy
+
+`current-spy-predicates` holds a list of predicate names that should be
+traced. When a spied predicate is called, Athena prompts for an action:
+
+```
+Spy on <goal>? [l=leap c=creep n=nodebug b=break]
+```
+
+* `c` – show this call and continue prompting at the next spy point.
+* `l` – leap: always show spy messages without further prompts.
+* `n` – nodebug: skip spy output for this call.
+* `b` – open a simple Scheme REPL and resume with `continue`.
+
+Example usage:
+
+```scheme
+(parameterize ((current-spy-predicates '(ancestor)))
+  (?- (ancestor alice ?x)))
+```
+
 ## License
 
 This project is licensed under the GNU General Public License v3.0. See [LICENSE](LICENSE) for the full terms.

--- a/prolog.rkt
+++ b/prolog.rkt
@@ -9,7 +9,7 @@
  current-clause-database primitive-clause-database
  standard-clause-database
  add-clause! get-clauses <- <-- define-predicate
- prove-all ?- current-lisp-environment
+ prove-all ?- current-lisp-environment current-spy-predicates
  success-bindings success-continuation prolog %prolog)
 
 (require (only-in srfi/1 alist-delete alist-cons delete-duplicates)

--- a/prolog.sld
+++ b/prolog.sld
@@ -7,12 +7,13 @@
     current-clause-database primitive-clause-database
     standard-clause-database
     add-clause! get-clauses <- <-- define-predicate prove-all ?-
-    current-lisp-environment
+    current-lisp-environment current-spy-predicates
     success-bindings success-continuation prolog %prolog)
 
   (import (scheme base)
           (scheme eval)
           (scheme write)
+          (scheme read)
           (only (srfi 1) alist-delete filter delete-duplicates alist-cons))
 
   (cond-expand

--- a/prolog.sls
+++ b/prolog.sls
@@ -9,7 +9,7 @@
     current-clause-database primitive-clause-database
     standard-clause-database
     add-clause! get-clauses <- <-- define-predicate
-    prove-all ?- current-lisp-environment
+    prove-all ?- current-lisp-environment current-spy-predicates
     success-bindings success-continuation prolog %prolog)
 
   ;; Imports ------------------------------------------------------------------

--- a/test.scm
+++ b/test.scm
@@ -319,4 +319,6 @@
       (solve-first '((q ?y) (p ?y)) '?y))
     ))
 
+
+
 (test-end "prolog")


### PR DESCRIPTION
## Summary
- refine spy prompt to use familiar Prolog letters
- document spy usage in README

## Testing
- `nix develop -c make all`

------
https://chatgpt.com/codex/tasks/task_b_6854b0cdbfe88322bcad7ac4656c14a8