### PR TITLE
Enable curried call semantics

### DIFF
--- a/prolog.scm
+++ b/prolog.scm
@@ -415,6 +415,11 @@
     (write resolved)
     (newline)))
 
+(define (flatten-call-goal g)
+  (if (and (pair? g) (pair? (car g)))
+      (flatten-call-goal (cons (caar g) (append (cdar g) (cdr g))))
+      g))
+
 (define-predicate (= term1 term2)
   (let ((new-bindings (unify term1 term2 (current-bindings))))
     (prove-all (current-remaining-goals) new-bindings)))
@@ -434,9 +439,10 @@
   (call/cc
    (lambda (choice-point)
      (let* ((substituted-goal (substitute-bindings (current-bindings) goal))
-         (cut-goals (insert-choice-point (list substituted-goal) choice-point))
-         (next-goals (append cut-goals (current-remaining-goals))))
-    (prove-all next-goals (current-bindings))))))
+            (flat-goal (flatten-call-goal substituted-goal))
+            (cut-goals (insert-choice-point (list flat-goal) choice-point))
+            (next-goals (append cut-goals (current-remaining-goals))))
+       (prove-all next-goals (current-bindings))))))
 
 (define-predicate (--lisp-eval-internal result-variable expression)
   (let* ((scheme-expression (substitute-bindings (current-bindings) expression))

--- a/test.scm
+++ b/test.scm
@@ -143,6 +143,7 @@
 
   (test-equal "call/1 simple" 'mary (solve-first '((call (parent john ?x))) '?x))
   (test-equal "call/1 with conjunction" '(mary michael susan david) (solve-all '((call (ancestor john ?gc))) '?gc))
+  (test-equal "call supports curry" 'mary (solve-first '((call ((parent john) ?x))) '?x))
 
   (test-equal "if/3 then" 'yes (solve-first '((if (= a a) (= ?r yes) (= ?r no))) '?r))
   (test-equal "if/3 else" 'no (solve-first '((if (= a b) (= ?r yes) (= ?r no))) '?r))


### PR DESCRIPTION
## Summary
- allow `call` to flatten nested goals
- test that nested call behaves like a single call

## Testing
- `nix develop -c make all`

------
https://chatgpt.com/codex/tasks/task_b_6854d6a1fb848322a635de54ab9789df