### PR TITLE
Enable Gambit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ chez:
 	scheme --libdirs $$CHEZSCHEMELIBDIRS:$$PWD --script test.chez.scm
 
 gambit:
-	# gsi -:r7rs . test.seven.scm
+	gsi -:r7rs test.gambit.scm
 
 biwa:
 	biwas test.biwa.scm

--- a/prolog.gambit.scm
+++ b/prolog.gambit.scm
@@ -1,0 +1,21 @@
+(import (scheme base)
+        (scheme eval)
+        (scheme write)
+        (scheme read)
+        (only (srfi 1) alist-delete filter delete-duplicates alist-cons)
+        (only (srfi 132) list-sort))
+
+(define-record-type <failure> (make-failure) failure?)
+(define-record-type <success>
+  (make-success bindings continuation) success?
+  (bindings success-bindings)
+  (continuation success-continuation))
+
+(define (object->string object)
+  (parameterize ((current-output-port (open-output-string)))
+    (write object)
+    (get-output-string (current-output-port))))
+
+(include "prolog.scm")
+
+(current-lisp-environment (interaction-environment))

--- a/test.gambit.scm
+++ b/test.gambit.scm
@@ -1,0 +1,6 @@
+(import (scheme base)
+        (scheme r5rs)
+        (srfi 64))
+(include "prolog.gambit.scm")
+(current-lisp-environment (interaction-environment))
+(include "test.scm")


### PR DESCRIPTION
## Summary
- enable Gambit test target
- add Gambit specific wrapper for the Prolog engine
- add test driver for Gambit

## Testing
- `nix develop -c make all`
- `nix develop -c make gambit`

------
https://chatgpt.com/codex/tasks/task_b_68589179858083228441bb64574ce692