### PR TITLE
Fix cycle handling in substitute-bindings

### DIFF
--- a/src/prolog.scm
+++ b/src/prolog.scm
@@ -56,8 +56,8 @@
               (substitute-bindings bindings value (cons expression visited)))))
        ((atom? expression) expression)
        (else
-        (let* ((substituted-car (substitute-bindings bindings (car expression)))
-               (substituted-cdr (substitute-bindings bindings (cdr expression))))
+        (let* ((substituted-car (substitute-bindings bindings (car expression) visited))
+               (substituted-cdr (substitute-bindings bindings (cdr expression) visited)))
           (cons substituted-car substituted-cdr))))))
 
   (define (variables-in expression)

--- a/test/test.scm
+++ b/test/test.scm
@@ -37,6 +37,18 @@
     (test-equal "substitute-bindings simple" 'foo (substitute-bindings bindings '?x))
     (test-equal "substitute-bindings with list" '(g foo (bar)) (substitute-bindings bindings '(g ?x ?y))))
 
+  (let* ((cycle-bindings (cons (cons '?x '?y)
+                               (cons (cons '?y '?x) '()))))
+    (test-equal "substitute-bindings simple cycle"
+                '?x
+                (substitute-bindings cycle-bindings '?x)))
+
+  (let* ((nested-bindings (cons (cons '?x '(a ?y))
+                                (cons (cons '?y '(b ?x)) '()))))
+    (test-equal "substitute-bindings nested cycle"
+                '(a (b ?x))
+                (substitute-bindings nested-bindings '?x)))
+
   (test-equal "variables-in simple" '(?x ?y) (variables-in '(f ?x (g ?y ?x))))
   (test-equal "variables-in with no vars" '() (variables-in '(a b (c))))
 


### PR DESCRIPTION
## Summary
- pass visited list to recursive calls in `substitute-bindings`
- previous regression tests already cover cycles

## Testing
- `nix develop -c make IMPLS=gauche`
- `nix develop -c make all`


------
https://chatgpt.com/codex/tasks/task_b_6867758ac7bc8322852c8e9c7614df9a